### PR TITLE
Create SPARKBOX-SETUP.md

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,15 @@ jobs:
           - v1-dependencies-{{ checksum "composer.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
+      
+      - run:
+         name: Install PHP libzip-dev
+         command: sudo apt-get install -y libzip-dev
 
+      - run:
+         name: Install zip package for PHP
+         command: sudo docker-php-ext-install zip
+         
       - run: composer install -n --prefer-dist
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+# PHP CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-php/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/php:7.0.22-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mysql:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "composer.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          paths:
+            - ./vendor
+          key: v1-dependencies-{{ checksum "composer.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/php:7.0.22-browsers
+      - image: circleci/php:7.0.4-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/php:7.0.4-browsers
+      - image: circleci/php:7.0.27-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/SPARKBOX-SETUP.md
+++ b/SPARKBOX-SETUP.md
@@ -1,0 +1,99 @@
+# Sparkbox - Craft
+
+A fork of Craft CMS - https://github.com/craftcms/craft
+
+## Table of Contents
+
+* [Install and Configure Craft](#install-and-configure-craft)
+    * [Install and Configure Apache](#install-and-configure-apache)
+    * [Installing MySQL](#installing-mysql)
+    * [Install Sequel Pro](#install-sequel-pro)
+    * [Sparkbox Craft Install](#sparkbox-craft-install)
+    * [Create Craft Project Database](#create-craft-project-database)
+    * [Run Craft](#run-craft)
+* [Common Issues](#common-issues)
+    * [Fields Not Saving](#fields-not-saving)
+        
+## Install and Configure Craft
+
+### Install and Configure Apache
+
+Follow the [Apache at Sparkbox](https://github.com/sparkbox/standard/tree/master/software/apache) guide in the Standard to install and configure Apache on your machine.
+
+### Installing MySQL
+
+We will not be using homebrew for mysql installations.
+
+Install the MySQL Binary: [https://dev.mysql.com/downloads/mysql/](https://dev.mysql.com/downloads/mysql/) 
+
+
+Download and follow setup instructions.
+
+**For MySQL 5.7 +**
+
+**After installing, you’ll need to do the following:**
+
+	$ touch /etc/my.cnf
+
+Add:
+
+
+	[mysqld]
+	sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+
+[https://craftcookbook.net/recipes/making-craft-play-nicely-with-mysql-5-7-5](https://craftcookbook.net/recipes/making-craft-play-nicely-with-mysql-5-7-5) 
+
+### Install Sequel Pro
+
+Using the link:
+
+[https://sequelpro.com/download#auto-start](https://sequelpro.com/download#auto-start) 
+
+Download and install the binary for Sequel Pro. This (free) application will be able to create databases, users, and export/import data from external databases.
+
+### Sparkbox Craft Install
+
+If you are creating the repo, you’ll need to run this command, which will grab all the composer files from our starter kit and setup the project. 
+
+	$ composer create-project -s beta sparkbox/craft <your_project_name>
+
+If you are cloning an existing already created project, but have not yet run composer install, you should be able to simply run that command inside the project directory.
+
+	$ composer install
+  
+### Create Craft Project Database
+
+Login to mysql as root
+
+	$ mysql -u root -p
+
+Create your database
+
+	mysql create database db_name;
+
+Check that your database exists
+
+	mysql show databases;
+
+If you want to create a specific user for that database (instead of using root), you can do that here as well
+
+	mysql create user db_user;
+	mysql grant select, insert, delete, update on db_name.* to 'db_user'@'localhost' identified by 'db_password';
+
+Tell Craft how to access your database by updating the .env file in your project directory with the database name, user, and password.
+
+
+### Run Craft
+
+In your browser, go to `<your_project_name>.local/admin`. You should get a screen with a button to install Craft. Click that, create an account, and you should be good to go!
+
+## Common Issues
+### Fields Not Saving
+
+If you run into a situation where you add a field inside the Craft CMS and it does not save (even though it appears to at first and there are no error messages) you may need to increase your PHP max-input-vars.
+
+To fix this, add this line to your .htaccess file:
+
+	php_value max_input_vars 5000
+
+Make sure this change also gets made on the server for any versions of your app that are using a shared .htaccess file.


### PR DESCRIPTION
I went ahead and created a SPARKBOX-SETUP file with more than just the Common Issues section, providing a link to the Apache setup doc in the Standard and bringing back the info on setting up the database and installing Craft itself. 

- Add info from old README about setting up database and installing Craft
- Add Common Issues section